### PR TITLE
ERC-7930 : Fix chain type for eip155

### DIFF
--- a/ERCS/erc-7930.md
+++ b/ERCS/erc-7930.md
@@ -140,11 +140,11 @@ The interop roadmap is better served by having a standardized binary format for 
 Chain: Ethereum Mainnet
 Address: `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045`
 
-Interoperable Name: `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eip155:1#4CA88C9C`
+Interoperable Name: `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eip155:1#7C551245`
 
 Interoperable Address:
 ```
-0x00010000010114D8DA6BF26964AF9D7EED9E03E53415D37AA96045
+0x00010001010114D8DA6BF26964AF9D7EED9E03E53415D37AA96045
   ^^^^-------------------------------------------------- Version:              decimal 1
       ^^^^---------------------------------------------- ChainType:            2 bytes of CAIP namespace
           ^^-------------------------------------------- ChainReferenceLength: decimal 1
@@ -152,7 +152,7 @@ Interoperable Address:
               ^^---------------------------------------- AddressLength:        decimal 20
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Address:              20 bytes of ethereum address
 ```
-keccak256 input for checksum: `0x0000010114D8DA6BF26964AF9D7EED9E03E53415D37AA96045`
+keccak256 input for checksum: `0x0001010114D8DA6BF26964AF9D7EED9E03E53415D37AA96045`
 note the version field is removed before hashing
 
 ### Example 2: Solana mainnet address
@@ -178,18 +178,18 @@ Note the version field is removed before hashing.
 ### Example 3: EVM address without chainid
 Chain: `eip155` namespace, chainid not specified.
 Address: `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045`
-Interoperable Name: `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eip155#144A4B21`
+Interoperable Name: `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eip155#92D0CFBA`
 
 Interoperable Address:
 ```
-0x000100000014D8DA6BF26964AF9D7EED9E03E53415D37AA96045
+0x000100010014D8DA6BF26964AF9D7EED9E03E53415D37AA96045
   ^^^^------------------------------------------------ Version:              decimal 1
       ^^^^-------------------------------------------- ChainType:            2 bytes of CAIP namespace
           ^^------------------------------------------ ChainReferenceLength: zero, indicating no chainid
             ^^---------------------------------------- AddressLength:        decimal 20
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Address:              20 bytes of ethereum address
 ```
-keccak256 input for checksum: `0x000100000014D8DA6BF26964AF9D7EED9E03E53415D37AA96045`
+keccak256 input for checksum: `0x000100010014D8DA6BF26964AF9D7EED9E03E53415D37AA96045`
 Note the version field is removed before hashing.
 
 ### Example 4: Solana mainnet network, no address
@@ -216,11 +216,11 @@ Note the version field is removed before hashing.
 Chain: Arbitrum One
 Address: `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045`
 
-Interoperable Name: `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eip155:42161#D2E02854`
+Interoperable Name: `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eip155:42161#D98CB61C`
 
 Interoperable Address:
 ```
-0x0001000002A4B114D8DA6BF26964AF9D7EED9E03E53415D37AA96045
+0x0001000102A4B114D8DA6BF26964AF9D7EED9E03E53415D37AA96045
   ^^^^---------------------------------------------------- Version:              decimal 1
       ^^^^------------------------------------------------ ChainType:            2 bytes of CAIP namespace
           ^^---------------------------------------------- ChainReferenceLength: decimal 2
@@ -228,7 +228,7 @@ Interoperable Address:
                 ^^---------------------------------------- AddressLength:        decimal 20
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Address:              20 bytes of ethereum address
 ```
-keccak256 input for checksum: `0x000002A4B114D8DA6BF26964AF9D7EED9E03E53415D37AA96045`
+keccak256 input for checksum: `0x000102A4B114D8DA6BF26964AF9D7EED9E03E53415D37AA96045`
 note the version field is removed before hashing
 
 ## Security Considerations


### PR DESCRIPTION
[CAIP-50 documents that eip155 chains should use chainType `1`](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-50.md#registry-table)

This PR fixes the examples that use `0` instead of `1` to describe eip155 chains